### PR TITLE
Make spacy extension name ("negex") variable

### DIFF
--- a/negspacy/negation.py
+++ b/negspacy/negation.py
@@ -221,17 +221,17 @@ class Negex:
                     if e.label_ not in self.ent_types:
                         continue
                 if any(pre < e.start for pre in [i[1] for i in sub_preceding]):
-                    e._.negex = True
+                    e._.set(extension_name, True)
                     continue
                 if any(fol > e.end for fol in [i[2] for i in sub_following]):
-                    e._.negex = True
+                    e._.set(extension_name, True)
                     continue
                 if self.chunk_prefix:
                     if any(
                         c.text.lower() == doc[e.start].text.lower()
                         for c in self.chunk_prefix
                     ):
-                        e._.negex = True
+                        e._.set(extension_name, True)
         return doc
 
     def __call__(self, doc):

--- a/negspacy/negation.py
+++ b/negspacy/negation.py
@@ -88,6 +88,7 @@ class Negex:
         self.matcher.add("Termination", None, *self.termination_patterns)
         self.nlp = nlp
         self.ent_types = ent_types
+        self.extension_name = extension_name
 
         self.chunk_prefix = list(nlp.tokenizer.pipe(chunk_prefix))
 
@@ -223,17 +224,17 @@ class Negex:
                     if e.label_ not in self.ent_types:
                         continue
                 if any(pre < e.start for pre in [i[1] for i in sub_preceding]):
-                    e._.set(extension_name, True)
+                    e._.set(self.extension_name, True)
                     continue
                 if any(fol > e.end for fol in [i[2] for i in sub_following]):
-                    e._.set(extension_name, True)
+                    e._.set(self.extension_name, True)
                     continue
                 if self.chunk_prefix:
                     if any(
                         c.text.lower() == doc[e.start].text.lower()
                         for c in self.chunk_prefix
                     ):
-                        e._.set(extension_name, True)
+                        e._.set(self.extension_name, True)
         return doc
 
     def __call__(self, doc):

--- a/negspacy/negation.py
+++ b/negspacy/negation.py
@@ -36,6 +36,7 @@ class Negex:
         nlp,
         language="en_clinical",
         ent_types=list(),
+        extension_name="negex",
         pseudo_negations=list(),
         preceding_negations=list(),
         following_negations=list(),
@@ -49,8 +50,8 @@ class Negex:
                 "your own termsets when initializing Negex."
             )
         termsets = LANGUAGES[language]
-        if not Span.has_extension("negex"):
-            Span.set_extension("negex", default=False, force=True)
+        if not Span.has_extension(extension_name):
+            Span.set_extension(extension_name, default=False, force=True)
 
         if not pseudo_negations:
             if not "pseudo_negations" in termsets:

--- a/negspacy/negation.py
+++ b/negspacy/negation.py
@@ -20,6 +20,8 @@ class Negex:
         list of entity types to negate
     language: str
         language code, if using default termsets (e.g. "en" for english)
+    extension_name: str
+        defaults to "negex"; whether entity is negated is then available as ent._.negex
     pseudo_negations: list
         list of phrases that cancel out a negation, if empty, defaults are used
     preceding_negations: list


### PR DESCRIPTION
Currently it is not possible to add a second instance of NegEx to a spaCy pipeline, as this would simply overwrite the registered "negex" extension from the first instance:
```python
Span.set_extension("negex", default=False, force=True)
```
This PR makes it possible to set the name of the extension (while keeping the default of "negex"). This solution was proposed here: https://github.com/jenojp/negspacy/issues/17#issuecomment-661018290. 

My use case is similar: I also wanted to detect other context-based modifiers (e.g. speculations), while keeping them separate from the detected negations. This works now for my use case, and the default behavior is unchanged. But I'm not sure this is exactly what you had in mind, or whether you'd like to add this to negspacy at all, so please feel free to disregard or (request me to) make further changes.