### PR TITLE
chore(lint): replace pre-commit config with ruff + hygiene hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,16 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.3.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.11
     hooks:
-    -   id: check-yaml
-    -   id: end-of-file-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 22.10.0
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
     hooks:
-    -   id: black
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,61 @@
 # Contributing
 
-:tada: Thanks for your interest in this project :tada:
+Thanks for your interest in negspacy!
 
-* Please submit an issue request for any bugs, feature requests, or questions.
-* Feel free to fork the repo and submit a pull request.
-* Please use [Black](https://github.com/ambv/black) to format code before submitting.
+## Reporting issues
+
+Please open a GitHub issue for any bugs, feature requests, or questions.
+
+## Development setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+pip install -e ".[dev]"
+python -m spacy download en_core_web_sm
+pre-commit install
+```
+
+[uv](https://github.com/astral-sh/uv) is also supported and faster:
+
+```bash
+uv venv && uv pip install -e ".[dev]"
+```
+
+## Running tests
+
+```bash
+pytest
+```
+
+With coverage:
+
+```bash
+pytest --cov=negspacy --cov-report=term-missing
+```
+
+## Linting and formatting
+
+[ruff](https://docs.astral.sh/ruff/) handles linting and formatting (replacing Black, isort, and flake8).
+
+```bash
+# check
+ruff check .
+# auto-fix
+ruff check --fix .
+# format
+ruff format .
+```
+
+pre-commit runs ruff automatically on every commit. To run manually across all files:
+
+```bash
+pre-commit run --all-files
+```
+
+## Pull requests
+
+- Fork the repo and open a PR against `master`.
+- Keep PRs small and focused — one concern per PR.
+- All tests must pass before review.
+- Do not push directly to `master`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # negspacy: negation for spaCy
 
-[![Build Status](https://dev.azure.com/jenopizzaro/negspacy/_apis/build/status/jenojp.negspacy?branchName=master)](https://dev.azure.com/jenopizzaro/negspacy/_build/latest?definitionId=2&branchName=master) [![Built with spaCy](https://img.shields.io/badge/made%20with%20❤%20and-spaCy-09a3d5.svg)](https://spacy.io) [![pypi Version](https://img.shields.io/pypi/v/negspacy.svg?style=flat-square)](https://pypi.org/project/negspacy/) [![DOI](https://zenodo.org/badge/201071164.svg)](https://zenodo.org/badge/latestdoi/201071164) 
+[![Build Status](https://dev.azure.com/jenopizzaro/negspacy/_apis/build/status/jenojp.negspacy?branchName=master)](https://dev.azure.com/jenopizzaro/negspacy/_build/latest?definitionId=2&branchName=master) [![Built with spaCy](https://img.shields.io/badge/made%20with%20❤%20and-spaCy-09a3d5.svg)](https://spacy.io) [![pypi Version](https://img.shields.io/pypi/v/negspacy.svg?style=flat-square)](https://pypi.org/project/negspacy/) [![DOI](https://zenodo.org/badge/201071164.svg)](https://zenodo.org/badge/latestdoi/201071164)
 
 spaCy pipeline object for negating concepts in text. Based on the NegEx algorithm.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ addopts = "-ra --strict-markers --strict-config"
 [tool.ruff]
 line-length = 100
 target-version = "py39"
+extend-exclude = ["tests/_scispacy_dep.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I", "UP", "B", "SIM", "RUF"]

--- a/src/negspacy/negation.py
+++ b/src/negspacy/negation.py
@@ -107,14 +107,10 @@ class Negex:
         self.pseudo_patterns = list(self.nlp.tokenizer.pipe(self.pseudo_negations))
         self.matcher.add("pseudo", self.pseudo_patterns)
 
-        self.preceding_patterns = list(
-            self.nlp.tokenizer.pipe(self.preceding_negations)
-        )
+        self.preceding_patterns = list(self.nlp.tokenizer.pipe(self.preceding_negations))
         self.matcher.add("Preceding", self.preceding_patterns)
 
-        self.following_patterns = list(
-            self.nlp.tokenizer.pipe(self.following_negations)
-        )
+        self.following_patterns = list(self.nlp.tokenizer.pipe(self.following_negations))
         self.matcher.add("Following", self.following_patterns)
 
         self.termination_patterns = list(self.nlp.tokenizer.pipe(self.termination))
@@ -207,9 +203,7 @@ class Negex:
         return boundaries
 
     @staticmethod
-    def yield_spans_within_boundary(
-        doc: Doc, boundary: tuple[int, int], span_keys: set[str]
-    ):
+    def yield_spans_within_boundary(doc: Doc, boundary: tuple[int, int], span_keys: set[str]):
         """
         Yield spans that start and end within a boundary
         """
@@ -259,7 +253,7 @@ class Negex:
                 for span in self.yield_spans_within_boundary(doc, boundary, self.span_keys):
                     self._apply_negation(span, sub_preceding, sub_following)
             else:
-                for e in doc[boundary[0]: boundary[1]].ents:
+                for e in doc[boundary[0] : boundary[1]].ents:
                     self._apply_negation(e, sub_preceding, sub_following)
         return doc
 

--- a/src/negspacy/termsets.py
+++ b/src/negspacy/termsets.py
@@ -98,7 +98,8 @@ LANGUAGES["en"] = en
 
 # en_clinical builds upon en
 en_clinical = dict()
-pseudo_clinical = pseudo + [
+pseudo_clinical = [
+    *pseudo,
     "gram negative",
     "not rule out",
     "not ruled out",
@@ -110,7 +111,8 @@ pseudo_clinical = pseudo + [
 ]
 en_clinical["pseudo_negations"] = pseudo_clinical
 
-preceding_clinical = preceding + [
+preceding_clinical = [
+    *preceding,
     "patient was not",
     "without indication of",
     "without sign of",
@@ -141,10 +143,11 @@ preceding_clinical = preceding + [
 ]
 en_clinical["preceding_negations"] = preceding_clinical
 
-following_clinical = following + ["was ruled out", "were ruled out", "free"]
+following_clinical = [*following, "was ruled out", "were ruled out", "free"]
 en_clinical["following_negations"] = following_clinical
 
-termination_clinical = termination + [
+termination_clinical = [
+    *termination,
     "cause for",
     "cause of",
     "causes for",
@@ -172,7 +175,8 @@ LANGUAGES["en_clinical"] = en_clinical
 
 en_clinical_sensitive = dict()
 
-preceding_clinical_sensitive = preceding_clinical + [
+preceding_clinical_sensitive = [
+    *preceding_clinical,
     "concern for",
     "supposed",
     "which causes",

--- a/tests/_scispacy_dep.py
+++ b/tests/_scispacy_dep.py
@@ -1,9 +1,5 @@
-import pytest
 import spacy
-import copy
-import negation
 from termsets import termset
-from spacy.pipeline import EntityRuler
 
 
 def build_med_docs():

--- a/tests/test_negation.py
+++ b/tests/test_negation.py
@@ -1,7 +1,7 @@
+from spacy.language import Language
+
 import negspacy.negation  # noqa: F401
 from negspacy.termsets import termset
-from spacy.language import Language
-from spacy.pipeline import EntityRuler
 
 
 def build_docs():
@@ -71,14 +71,12 @@ def test_own_terminology(nlp):
         last=True,
     )
     doc = nlp("He does not like Steve Jobs whatever he says about Barack Obama.")
-    assert doc.ents[1]._.negex == False
+    assert not doc.ents[1]._.negex
 
 
 def test_issue7(nlp):
     nlp.add_pipe("negex", last=True)
-    ruler = EntityRuler(nlp)
-    patterns = [{"label": "SOFTWARE", "pattern": "spacy"}]
-    doc = nlp("fgfgdghgdh")
+    nlp("fgfgdghgdh")
 
 
 def ents_to_spans(doc):

--- a/tests/test_termsets.py
+++ b/tests/test_termsets.py
@@ -6,7 +6,7 @@ from negspacy.termsets import termset
 def test_get_patterns():
     ts = termset("en")
     patterns = ts.get_patterns()
-    assert type(patterns) == dict
+    assert isinstance(patterns, dict)
     assert len(patterns) == 4
 
 
@@ -23,16 +23,10 @@ def test_add_remove_patterns():
     )
     patterns_after = ts.get_patterns()
 
-    assert len(patterns_after["pseudo_negations"]) - 1 == len(
-        patterns["pseudo_negations"]
-    )
+    assert len(patterns_after["pseudo_negations"]) - 1 == len(patterns["pseudo_negations"])
     assert len(patterns_after["termination"]) - 2 == len(patterns["termination"])
-    assert len(patterns_after["preceding_negations"]) - 1 == len(
-        patterns["preceding_negations"]
-    )
-    assert len(patterns_after["following_negations"]) - 1 == len(
-        patterns["following_negations"]
-    )
+    assert len(patterns_after["preceding_negations"]) - 1 == len(patterns["preceding_negations"])
+    assert len(patterns_after["following_negations"]) - 1 == len(patterns["following_negations"])
 
     ts.remove_patterns(
         {
@@ -44,12 +38,6 @@ def test_add_remove_patterns():
     )
     patterns_after = ts.get_patterns()
     assert len(patterns_after["termination"]) == len(patterns["termination"])
-    assert (
-        len(patterns_after["following_negations"])
-        == len(patterns["following_negations"]) - 1
-    )
-    assert (
-        len(patterns_after["preceding_negations"])
-        == len(patterns["preceding_negations"]) - 1
-    )
+    assert len(patterns_after["following_negations"]) == len(patterns["following_negations"]) - 1
+    assert len(patterns_after["preceding_negations"]) == len(patterns["preceding_negations"]) - 1
     assert len(patterns_after["pseudo_negations"]) == len(patterns["pseudo_negations"])


### PR DESCRIPTION
## Motivation

`.pre-commit-config.yaml` pinned `pre-commit-hooks` v2.3.0 (2019) and `black` v22.10.0. Black is no longer the project formatter — ruff handles everything. `CONTRIBUTING.md` still told contributors to use Black. This PR replaces both — per [PR #3 in the modernization plan](../blob/modernize/2026/MODERNIZATION_PLAN.md).

## What changed

**`.pre-commit-config.yaml`** — full replacement
- Removed: `pre-commit-hooks` v2.3.0, `black` v22.10.0
- Added: `ruff-pre-commit` v0.15.11 (`ruff --fix` + `ruff-format`) and `pre-commit-hooks` v6.0.0 (resolved via `pre-commit autoupdate`)
- Hygiene hooks: `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-toml`, `check-added-large-files`, `check-merge-conflict`

**`pyproject.toml`** — added `extend-exclude = ["tests/_scispacy_dep.py"]` under `[tool.ruff]` so the quarantined broken file is not linted until PR #6 addresses it.

**One-pass `pre-commit run --all-files` sweep** — all issues fixed in this single commit:
| File | Rule | Fix |
|---|---|---|
| `src/negspacy/termsets.py` | RUF005 (×5) | List concatenation → iterable unpacking (`[*x, ...]`) |
| `tests/test_negation.py` | E712 | `== False` → `not` |
| `tests/test_negation.py` | F841 (×3) | Remove unused vars from dead `test_issue7` |
| `tests/test_negation.py` | F401 | Drop unused `EntityRuler` import |
| `tests/test_termsets.py` | E721 | `type() == dict` → `isinstance()` |
| `README.md` | trailing-whitespace | Auto-fixed |
| `src/negspacy/negation.py` | ruff-format | Import order (cosmetic) |

**`CONTRIBUTING.md`** — full rewrite
- Removed Black reference
- Added dev setup (venv + uv variants), pytest with coverage, ruff commands, pre-commit usage
- Updated PR guidelines

## What did NOT change

- Termset data (`en`, `en_clinical`, `en_clinical_sensitive`) — only construction syntax changed, values are identical
- Negation algorithm — untouched
- Public API — untouched
- `azure-pipelines.yml` — left for PR #4

## Test evidence

```
$ pre-commit run --all-files
ruff (legacy alias)......... Passed
ruff format................. Passed
trim trailing whitespace.... Passed
fix end of files............ Passed
check yaml.................. Passed
check toml.................. Passed
check for added large files. Passed
check for merge conflicts... Passed

$ pytest
7 passed in 0.62s
```

## Reviewer checklist

- [ ] `pre-commit install && pre-commit run --all-files` passes on a clean checkout
- [ ] Termset list contents are unchanged (only syntax: `pseudo + [...]` → `[*pseudo, ...]`)
- [ ] `tests/_scispacy_dep.py` exclusion from ruff is acceptable until PR #6
- [ ] `CONTRIBUTING.md` dev-setup commands are accurate
