### PR TITLE
docs: seed CHANGELOG.md and document release process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,83 @@
+# Changelog
+
+All notable changes to `negspacy` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- `src/` package layout (`src/negspacy/`); prevents accidental imports of the in-development package during testing.
+- PEP 561 `py.typed` marker so downstream users pick up the library's type hints.
+- Top-level `tests/` directory with shared session-scoped `nlp` fixture in `conftest.py`; `test.py` split into `test_negation.py` and `test_termsets.py`.
+- GitHub Actions workflows: `ci.yml` (lint + test matrix across ubuntu/macos/windows × Python 3.10–3.13 + build) and `release.yml` (tag-triggered PyPI publish via OIDC trusted publishing).
+- Test coverage for previously uncovered paths: `chunk_prefix`, `ent_types` filtering, `extension_name` override, `span_keys` edge cases, termset `add_patterns`/`remove_patterns` round-trips and `ValueError` paths, `en_clinical_sensitive` and `es_clinical` termsets.
+- `scispacy`-dependent tests are now gated behind `pytest.importorskip("scispacy")` and skip cleanly when the optional model is not installed.
+- This `CHANGELOG.md`.
+
+### Changed
+- Packaging consolidated into a single `pyproject.toml` (PEP 621) using `hatchling` as the build backend. Version now lives in `src/negspacy/__init__.py` and is read dynamically by hatch.
+- Runtime dependency bumped to `spacy>=3.8,<4.0`.
+- Minimum Python bumped to `>=3.10` (spaCy 3.8 transitively requires `thinc>=8.3.12`, which dropped Python 3.9).
+- `PhraseMatcher.add(key, None, *patterns)` calls migrated to the modern `add(key, patterns)` signature, silencing spaCy 3.8 deprecation warnings.
+- Type hints updated to py310 builtins (`list[str]`, `X | None`).
+- Linting and formatting migrated from Black/isort/flake8 to `ruff` + `ruff-format`; `.pre-commit-config.yaml` refreshed.
+- CI migrated from Azure Pipelines to GitHub Actions.
+- `CONTRIBUTING.md` rewritten for the new development workflow and now documents the release process.
+- README build badge updated to point at the GitHub Actions workflow.
+
+### Removed
+- `setup.py`, `setup.cfg`, `requirements.txt`, and the tracked `negspacy.egg-info/` directory.
+- `azure-pipelines.yml`.
+- Support for Python 3.6 / 3.7 / 3.8 / 3.9.
+- Dead `test_issue7` test (had no assertions).
+
+### Fixed
+- Extracted the `process_span` closure in `negation.py` into an explicit `_apply_negation` method, fixing a latent loop-variable-capture issue (ruff B023) flagged by the updated linter.
+
+## [1.0.3] — 2022-05-25
+
+### Fixed
+- Code clean-up and speed improvements to the matcher pipeline.
+
+## [1.0.2] — 2022-01-20
+
+### Added
+- Spanish clinical termset (`es_clinical`), contributed by @j6e ([#51]).
+- Apply negex to `doc.spans` via the new `span_keys` config ([#57]).
+
+### Changed
+- Simplified span-group arguments — removed `use_spans` in favour of `span_keys`.
+
+## [1.0.1] — 2021-10-25
+
+### Fixed
+- Corrected the `psuedo_negations` → `pseudo_negations` key typo across built-in termsets.
+
+## [1.0.0] — 2021-02-22
+
+### Changed
+- **BREAKING:** rewritten for spaCy 3.0's new pipeline-component interface. The component is now registered via `@Language.factory("negex", ...)` and added with `nlp.add_pipe("negex", config={...})`. Direct `Negex(nlp, ...)` construction is no longer the public entry point. Not backwards-compatible with pre-1.0 users — pin `negspacy==0.1.9` if you still need spaCy 2.x support.
+- Termset management moved into a dedicated `termset` class exposing `get_patterns()`, `add_patterns()`, and `remove_patterns()`.
+
+## [0.1.9] — 2020-11-18
+
+### Added
+- `extension_name` config so multiple `Negex` instances can coexist in a single pipeline with distinct extension attributes.
+- `add_patterns` / `remove_patterns` helpers for modifying built-in termsets at runtime.
+
+### Changed
+- Default termset switched from `en` to `en_clinical`.
+
+---
+
+[Unreleased]: https://github.com/jenojp/negspacy/compare/v1.0.3...HEAD
+[1.0.3]: https://github.com/jenojp/negspacy/compare/v1.0.2...v1.0.3
+[1.0.2]: https://github.com/jenojp/negspacy/compare/1.0.1...v1.0.2
+[1.0.1]: https://github.com/jenojp/negspacy/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/jenojp/negspacy/compare/v0.1.9...1.0.0
+[0.1.9]: https://github.com/jenojp/negspacy/releases/tag/v0.1.9
+
+[#51]: https://github.com/jenojp/negspacy/pull/51
+[#57]: https://github.com/jenojp/negspacy/pull/57

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,3 +59,32 @@ pre-commit run --all-files
 - Keep PRs small and focused — one concern per PR.
 - All tests must pass before review.
 - Do not push directly to `master`.
+
+## Releasing
+
+Releases are fully automated. A pushed tag matching `v*` triggers `.github/workflows/release.yml`, which builds the sdist and wheel and uploads them to PyPI via [OIDC trusted publishing](https://docs.pypi.org/trusted-publishers/). No API tokens, no local `twine upload`.
+
+### Cutting a new release
+
+1. **Bump the version.** Edit `src/negspacy/__init__.py` and update `__version__`. This is the single source of truth — `pyproject.toml` reads it dynamically via `[tool.hatch.version]`.
+2. **Update `CHANGELOG.md`.** Move items from the `[Unreleased]` section into a new `[X.Y.Z] — YYYY-MM-DD` section and update the compare links at the bottom of the file. Leave an empty `[Unreleased]` stub above the new section.
+3. **Open a release PR** titled `release: vX.Y.Z` against `master`. CI must pass.
+4. **Merge the release PR** after maintainer review.
+5. **Tag the merge commit** from `master`:
+   ```bash
+   git checkout master && git pull
+   git tag vX.Y.Z
+   git push origin vX.Y.Z
+   ```
+6. **Watch the `release` workflow run** on GitHub Actions. On success, the new version is on PyPI within a minute.
+
+Do not publish to PyPI from a local machine, and do not commit API tokens.
+
+### One-time trusted-publisher setup (already configured)
+
+For reference — this has already been done for `negspacy` on PyPI and does not need to be repeated:
+
+- A trusted publisher is registered on the PyPI project page (PyPI → Your projects → `negspacy` → Publishing) binding the `jenojp/negspacy` repository, the workflow file `release.yml`, and the GitHub environment `pypi`.
+- A GitHub environment named `pypi` exists in the repository settings. `release.yml` references it via `environment: pypi`, which is what allows the OIDC token exchange to succeed.
+
+If the project is ever transferred to a new account or the workflow filename changes, the trusted-publisher registration must be updated on PyPI to match — otherwise the publish step will fail with an authentication error.


### PR DESCRIPTION
## Motivation

`CLAUDE.md` mandates a Keep a Changelog–format `CHANGELOG.md`, and the release flow (tag → OIDC publish) was not documented anywhere contributors or future maintainers would find it. Both are blockers before the next release can be cut safely.

The PyPI trusted publisher and the `pypi` GitHub environment have already been configured on the maintainer's side; this PR adds the companion written documentation so a future maintainer (or the author returning to the project after a year) can reproduce or repair the setup.

## What changed

### `CHANGELOG.md` (new)
- Seeded from git history in Keep a Changelog format.
- Back-filled sections for **1.0.3**, **1.0.2**, **1.0.1**, **1.0.0** (breaking spaCy 3.0 rewrite), and **0.1.9** (last spaCy 2.x release).
- **`[Unreleased]`** section captures everything the modernization effort (PRs #60–65) changed — Added / Changed / Removed / Fixed — so the next version bump only needs to rename the section and add a date.
- Compare links at the bottom of the file follow the standard Keep a Changelog pattern.

### `CONTRIBUTING.md`
- New **Releasing** section explains the end-to-end flow: bump `__version__` → update `CHANGELOG.md` → open release PR → tag `vX.Y.Z` on `master` → `release.yml` auto-publishes via OIDC.
- Documents the (already-completed) one-time PyPI trusted-publisher + GitHub-environment setup for reference, including what would break if the repo is transferred or the workflow filename changes.

## What did NOT change

- **No code changes.** No `src/` edits, no test edits, no workflow edits.
- `release.yml` already exists (added in PR #63) — this PR does not touch it.
- No version bump in this PR. Cutting an actual release is a separate, future operation.
- No PyPI- or Zenodo-side configuration is touched by this PR.

## Test evidence

```
18 passed, 1 skipped in 1.42s
ruff: All checks passed!
ruff format: 8 files already formatted
```

## Reviewer checklist

- [ ] `CHANGELOG.md` accurately reflects the modernization changes (compare `[Unreleased]` section against the 6 merged PRs: #60, #61, #62, #63, #64, #65).
- [ ] Back-filled version sections match your recollection of what shipped in each release.
- [ ] The "Releasing" section in `CONTRIBUTING.md` matches the trusted-publisher configuration you actually set up on PyPI (the workflow filename `release.yml` and the environment name `pypi` must agree with what's registered on the PyPI side).
- [ ] No secrets, API tokens, or private context included.

https://claude.ai/code/session_01BHjZWmQQYMQFKdBTQFKS3m